### PR TITLE
feat: Comparison to existing guilds

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -42,7 +42,7 @@ main {
 
 .container {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1.3fr 1fr;
     gap: 1.2em;
 }
 
@@ -79,7 +79,7 @@ main {
     padding: 20px;
 }
 
-#territory {
+.territoryText {
     display: flex;
     justify-content: center;
     align-items: center;

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,28 +1,66 @@
 "use strict";
 
 const checkLuma = ({ r, g, b }) => (0.2126 * r + 0.7152 * g + 0.0722 * b) >= 30;
+const checkClosestColor = (color, closestColor) => getDistanceBetweenColors(color, closestColor) >= 15;
 
 const setCopyrightYear = () => {
     let yearEl = document.getElementById("year");
     yearEl.innerHTML = new Date().getFullYear();
 }
 
-const isAllowedByWynntils = color => {
+/**
+ * @param color {tinycolor} - color to check
+ * @param closestColor {tinycolor} - closest existing guild color
+ */
+function isAllowedByWynntils(color, closestColor) {
     let allowedByWynntils = document.getElementById("allowed")
-    if (checkLuma(color.rgb)) {
-        allowedByWynntils.innerHTML = "Allowed";
-        allowedByWynntils.style.color = "#5f5";
+    if (checkLuma(color.toRgb())) {
+        if (checkClosestColor(color, closestColor)) {
+            allowedByWynntils.innerHTML = "Allowed";
+            allowedByWynntils.style.color = "#5f5";
+        } else {
+            allowedByWynntils.innerHTML = "Not allowed (too similar)";
+            allowedByWynntils.style.color = "#f55";
+        }
     } else {
-        allowedByWynntils.innerHTML = "Not allowed";
+        allowedByWynntils.innerHTML = "Not allowed (too dark)";
         allowedByWynntils.style.color = "#f55";
     }
 }
 
+/**
+ * @param hexValue {string} - hex value to validate
+ * @returns {boolean} - whether or not the hex value is valid
+ */
 const validateHex = hexValue => {
     let hex = document.getElementById("hex");
-    if (/^#[0-9a-f]{3}([0-9a-f]{3})?$/i.test(hexValue)) {
+    if (/^#?[0-9a-f]{3}([0-9a-f]{3})?$/i.test(hexValue)) {
         hex.style.color = '#5f5';
+        return true;
     } else {
         hex.style.color = '#f55';
+        return false;
     }
+}
+
+/**
+ * @param color1 {tinycolor}
+ * @param color2 {tinycolor}
+ * @returns {number} - distance between two colors (0-442)
+ */
+const getDistanceBetweenColors = (color1, color2) => {
+    // this is probably good enough to determine if a color is close enough to another color
+    // https://en.wikipedia.org/wiki/Color_difference#sRGB
+    // it gets rather complicated to get a more accurate result
+
+    if (color1 == null || color2 == null) {
+        // max of sqrt(255^2 * 3) = 441.7 (which is max distance between two colors)
+        return 442;
+    }
+
+    const rDiffSquared = Math.pow(color1.toRgb().r - color2.toRgb().r, 2);
+    const gDiffSquared = Math.pow(color1.toRgb().g - color2.toRgb().g, 2);
+    const bDiffSquared = Math.pow(color1.toRgb().b - color2.toRgb().b, 2);
+    const result = Math.sqrt(rDiffSquared + gDiffSquared + bDiffSquared);
+    return result
 }

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const checkLuma = ({ r, g, b }) => (0.2126 * r + 0.7152 * g + 0.0722 * b) >= 30;
-const checkClosestColor = (color, closestColor) => getDistanceBetweenColors(color, closestColor) >= 15;
+const checkClosestColor = (color, closestColor) => getDistanceBetweenColors(color, closestColor) >= 20;
 
 const setCopyrightYear = () => {
     let yearEl = document.getElementById("year");

--- a/index.html
+++ b/index.html
@@ -39,15 +39,21 @@
     </header>
     <div class="container">
       <section class="territoryContainer paperBorder">
-        <div id="territory">TAG</div>
+        <div class="territoryText" id="territory">TAG</div>
         <img src="./assets/images/detlas.png" alt="Map of Detlas" title="Map of Detlas" />
       </section>
 
       <section class="colorPickerContainer itemBorder">
         <h2>Choose a color:</h2>
         <div id="picker"></div>
-        <p>Allowed by Wynntils?: <span id="allowed">Undetermined</span></p>
-        <p>Hex Value: <input id="hex" placeholder="#000000"></input></p>
+        <span>Allowed by Wynntils?: <span id="allowed">Undetermined</span></span>
+        <span>Closest guild: <span id="closestGuild">Undetermined</span></span>
+        <span><label for="hex">Hex Value: </label><input id="hex" placeholder="#000000"></span>
+      </section>
+
+      <section class="territoryContainer paperBorder">
+        <div class="territoryText" id="closestExistingTerritory">TAG</div>
+        <img src="./assets/images/detlas.png" alt="Map of Detlas" title="Map of Detlas" />
       </section>
     </div>
     <footer class="footer">


### PR DESCRIPTION
- Updated text rendering to match Artemis
![image](https://github.com/wynncolor/wynncolor.github.io/assets/57310593/5e343975-e8f3-481e-ada0-27a8fef46614)
![image](https://github.com/wynncolor/wynncolor.github.io/assets/57310593/85edd057-012c-4aba-ae36-e97220ac7ab0)
- Hexes without # in front are now considered valid
- Invalid hexes don't update the previewed color anymore
- Reason for why colors are invalid
- Colors too close to an existing guild are marked invalid
- Closest guild is noted under the allowed text
- Some internal refactoring to consistently use tinycolor objects everywhere (but if you don't want this let me know, it just seems easier)